### PR TITLE
Greater robustness on project scanning

### DIFF
--- a/NSpec.TestAdapter/NSpecTestDiscoverer.cs
+++ b/NSpec.TestAdapter/NSpecTestDiscoverer.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -20,10 +22,12 @@ namespace NSpec.TestAdapter
 			{
 				using (var sandbox = new Sandbox<Discoverer>(source))
 				{
-					sandbox.Content
-						.DiscoverTests()
-						.Select(name => name.ToTestCase(source))
-						.ForEach(discoverySink.SendTestCase);
+					//System.Windows.Forms.MessageBox.Show("DEBUG: " + sandbox.IsValidTestProject);
+					if (sandbox.IsValidTestProject)
+						sandbox.Content
+							.DiscoverTests()
+							.Select(name => name.ToTestCase(source))
+							.ForEach(discoverySink.SendTestCase);
 				}
 			}
 		}

--- a/NSpec.TestAdapter/Sandbox.cs
+++ b/NSpec.TestAdapter/Sandbox.cs
@@ -22,11 +22,14 @@ namespace NSpec.TestAdapter
 			var assemblyDirectory = new DirectoryInfo(Path.GetDirectoryName(assemblyPath));
 			var projectDirectory = assemblyDirectory.Parent.Parent;
 			var solutionDirectory = FindSolutionDirectory(projectDirectory);
+			// Import the <assembly>.dll.app.config into the app domain
+			var appConfigFile = assemblyPath + ".config";
 			var setup = new AppDomainSetup
 			{
 				ShadowCopyFiles = "true",
 				LoaderOptimization = LoaderOptimization.MultiDomain,
 				ApplicationBase = solutionDirectory,
+				ConfigurationFile = System.IO.File.Exists(appConfigFile) ? appConfigFile : null,
 				PrivateBinPath = string.Join(";",
 					FindNSpec(projectDirectory),
 					assemblyDirectory.FullName.Remove(0, solutionDirectory.Length + 1))

--- a/NSpec.TestAdapter/Sandbox.cs
+++ b/NSpec.TestAdapter/Sandbox.cs
@@ -21,49 +21,68 @@ namespace NSpec.TestAdapter
 		{
 			var assemblyDirectory = new DirectoryInfo(Path.GetDirectoryName(assemblyPath));
 			var projectDirectory = assemblyDirectory.Parent.Parent;
-			var solutionDirectory = FindSolutionDirectory(projectDirectory);
-			// Import the <assembly>.dll.app.config into the app domain
-			var appConfigFile = assemblyPath + ".config";
+
+			var solutionDirectory = FindPackagesDirectory(projectDirectory);
+
+			// Can only continue if valid test project
+			if (!string.IsNullOrEmpty(solutionDirectory))
+				IsValidTestProject = true;
+			else
+				return;
+
+			//throw new DirectoryNotFoundException("Failed attempting to find 'packages' folder in any parent directories.");
+
+			var nSpecPath = FindNSpec(projectDirectory);
+			var privateBinPath = string.Join(";",
+				nSpecPath,
+				assemblyDirectory.FullName.Remove(0, solutionDirectory.Length + 1));
+
 			var setup = new AppDomainSetup
 			{
 				ShadowCopyFiles = "true",
 				LoaderOptimization = LoaderOptimization.MultiDomain,
 				ApplicationBase = solutionDirectory,
-				ConfigurationFile = System.IO.File.Exists(appConfigFile) ? appConfigFile : null,
-				PrivateBinPath = string.Join(";",
-					FindNSpec(projectDirectory),
-					assemblyDirectory.FullName.Remove(0, solutionDirectory.Length + 1))
+				PrivateBinPath = privateBinPath
 			};
+			
 			this.domain = AppDomain.CreateDomain("tests-sandbox", null, setup);
-
+			
 			var type = typeof(T);
 			this.Content = this.domain.CreateInstanceFromAndUnwrap(type.Assembly.Location, type.FullName) as T;
 			this.Content.Load(assemblyPath);
 		}
 
+		
 		/// <summary>
 		/// A sandboxed object.
 		/// </summary>
 		public T Content { get; private set; }
 
+		public bool IsValidTestProject { get; set; }
+
 		public void Dispose()
 		{
 			this.Content = null;
-			AppDomain.Unload(domain);
+			if (domain != null)
+				AppDomain.Unload(domain);
 		}
 
-		private string FindSolutionDirectory(DirectoryInfo projectDirectory)
+		private string FindPackagesDirectory(DirectoryInfo projectDirectory)
 		{
-			return projectDirectory.EnumerateDirectories("packages").Any()
+			if (projectDirectory == null) return null;
+			//System.Windows.Forms.MessageBox.Show("DEBUG: " + projectDirectory.FullName);
+			var anyDirectories = projectDirectory.EnumerateDirectories("packages").Any();
+			//System.Windows.Forms.MessageBox.Show("DEBUG: Package dir exists? " + anyDirectories);
+			return anyDirectories
 				? projectDirectory.FullName
-				: FindSolutionDirectory(projectDirectory.Parent);
+				: FindPackagesDirectory(projectDirectory.Parent);
 		}
 
 		private string FindNSpec(DirectoryInfo projectDirectory)
 		{
 			var packagesFile = Path.Combine(projectDirectory.FullName, "packages.config");
 			if (!File.Exists(packagesFile)) return null;
-
+			
 			var doc = XDocument.Load(packagesFile);
 			var nspecVersion = doc.Descendants("package")
 				.Where(p => p.Attribute("id").Value == "nspec")


### PR DESCRIPTION
This project has been altered to better handle the scanning process of all projects.

We found when this VSIX extension is used on a solution with many projects of varying types, class libraries, MVC applications, other test project types etc. the "Test Explorer" wasn't returning any results, and the output window was displaying: 
```
An exception occurred while test discoverer 'NSpecTestDiscoverer' was loading tests. Exception: Object reference not set to an instance of an object.
```

Technical information:
Previously, if the test adapter scanned and found other projects in the solution which were test projects, it was assuming they were nspec test projects and a packages\nspec* folder and associated files always existed, this is not always the case, and nspec test adapter would crash out with object reference errors because it couldn't find them.

Now, ALL projects included in the solution that are scanned, test project or not, we only deem them to be "content for the Sandbox" IF they have a packages\nspec* folder, instead of taking on the assumption that they have one and crashing out when it can't find one.