### PR TITLE
Add try/catch during discovery & execution. Extend logging

### DIFF
--- a/NSpec.TestAdapter.VSIX/source.extension.vsixmanifest
+++ b/NSpec.TestAdapter.VSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NSpec.TestAdapter.b8b5c223-2409-4345-9d62-0e4ceba87206" Version="0.3.0" Language="en-US" Publisher="{o} Software" />
+    <Identity Id="NSpec.TestAdapter.b8b5c223-2409-4345-9d62-0e4ceba87206" Version="0.4.0" Language="en-US" Publisher="{o} Software" />
     <DisplayName>NSpec Test Adapter</DisplayName>
     <Description xml:space="preserve">Run NSpec specifications from Test Explorer</Description>
     <MoreInfo>https://github.com/osoftware/NSpecTestAdapter/wiki</MoreInfo>

--- a/NSpec.TestAdapter/NSpec.TestAdapter.csproj
+++ b/NSpec.TestAdapter/NSpec.TestAdapter.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(ProgramFiles)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="NSpec">
       <HintPath>..\packages\nspec.0.9.68\lib\NSpec.dll</HintPath>

--- a/NSpec.TestAdapter/NSpec.TestAdapter.csproj
+++ b/NSpec.TestAdapter/NSpec.TestAdapter.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Sandbox.cs" />
     <Compile Include="TestCaseDTO.cs" />
+    <Compile Include="TestLogger.cs" />
     <Compile Include="TestResultDTO.cs" />
     <Compile Include="DomainProxy.cs" />
   </ItemGroup>

--- a/NSpec.TestAdapter/Properties/AssemblyInfo.cs
+++ b/NSpec.TestAdapter/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
+[assembly: AssemblyVersion("0.4.0.0")]
+[assembly: AssemblyFileVersion("0.4.0.0")]

--- a/NSpec.TestAdapter/TestLogger.cs
+++ b/NSpec.TestAdapter/TestLogger.cs
@@ -37,9 +37,10 @@ namespace NSpec.TestAdapter
 
         public void SendDebugMessage(string message)
         {
-#if DEBUG
-            SendMessage(TestMessageLevel.Informational, String.Format("[DBG] {0}", message));
-#endif
+            if (isDevBuild)
+            {
+                SendMessage(TestMessageLevel.Informational, String.Format("[DBG] {0}", message));
+            }
         }
 
         public void SendWarningMessage(string message)
@@ -49,9 +50,15 @@ namespace NSpec.TestAdapter
 
         public void SendWarningMessage(Exception ex, string message)
         {
-            SendWarningMessage(message);
-
-            SendWarningMessage(ex.ToString());
+            if (isDevBuild)
+            {
+                SendWarningMessage(message);
+                SendWarningMessage(ex.ToString());
+            }
+            else
+            {
+                SendWarningMessage(String.Format("Exception {0}, {1}", ex.GetType(), message));
+            }
         }
 
         public void SendErrorMessage(string message)
@@ -61,9 +68,15 @@ namespace NSpec.TestAdapter
 
         public void SendErrorMessage(Exception ex, string message)
         {
-            SendErrorMessage(message);
-
-            SendErrorMessage(ex.ToString());
+            if (isDevBuild)
+            {
+                SendErrorMessage(message);
+                SendErrorMessage(ex.ToString());
+            }
+            else
+            {
+                SendErrorMessage(String.Format("Exception {0}, {1}", ex.GetType(), message));
+            }
         }
 
         bool CanLog { get { return messageLogger != null; } }
@@ -72,5 +85,12 @@ namespace NSpec.TestAdapter
         readonly string adapterVersion;
 
         const string adapterName = "NSpec Test Adapter";
+
+        readonly bool isDevBuild = 
+#if DEBUG
+            true;
+#else
+            false;
+#endif
     }
 }

--- a/NSpec.TestAdapter/TestLogger.cs
+++ b/NSpec.TestAdapter/TestLogger.cs
@@ -38,7 +38,7 @@ namespace NSpec.TestAdapter
         public void SendDebugMessage(string message)
         {
 #if DEBUG
-            SendMessage(TestMessageLevel.Informational, String.Format("Debug: {0}", message));
+            SendMessage(TestMessageLevel.Informational, String.Format("[DBG] {0}", message));
 #endif
         }
 

--- a/NSpec.TestAdapter/TestLogger.cs
+++ b/NSpec.TestAdapter/TestLogger.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NSpec.TestAdapter
+{
+    public class TestLogger
+    {
+        public TestLogger(IMessageLogger messageLogger)
+        {
+            _messageLogger = messageLogger;
+
+            _adapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+        }
+
+        public void SendMessage(TestMessageLevel logLevel, string message)
+        {
+            if (CanLog)
+            {
+                _messageLogger.SendMessage(logLevel, message);
+            }
+        }
+
+        public void SendInformationalMessage(string message)
+        {
+            SendMessage(TestMessageLevel.Informational, message);
+        }
+
+        public void SendMainMessage(string message)
+        {
+            SendInformationalMessage(String.Format("{0} {1}: {2}", _adapterName, _adapterVersion, message));
+        }
+
+        public void SendDebugMessage(string message)
+        {
+#if DEBUG
+            SendMessage(TestMessageLevel.Informational, String.Format("Debug: {0}", message));
+#endif
+        }
+
+        public void SendWarningMessage(string message)
+        {
+            SendMessage(TestMessageLevel.Warning, message);
+        }
+
+        public void SendWarningMessage(Exception ex, string message)
+        {
+            SendWarningMessage(message);
+
+            SendWarningMessage(ex.ToString());
+        }
+
+        public void SendErrorMessage(string message)
+        {
+            SendMessage(TestMessageLevel.Error, message);
+        }
+
+        public void SendErrorMessage(Exception ex, string message)
+        {
+            SendErrorMessage(message);
+
+            SendErrorMessage(ex.ToString());
+        }
+
+        private bool CanLog { get { return _messageLogger != null; } }
+
+        private readonly IMessageLogger _messageLogger;
+        private readonly string _adapterVersion;
+
+        private const string _adapterName = "NSpec Test Adapter";
+    }
+}

--- a/NSpec.TestAdapter/TestLogger.cs
+++ b/NSpec.TestAdapter/TestLogger.cs
@@ -12,16 +12,16 @@ namespace NSpec.TestAdapter
     {
         public TestLogger(IMessageLogger messageLogger)
         {
-            _messageLogger = messageLogger;
+            this.messageLogger = messageLogger;
 
-            _adapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            adapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
         }
 
         public void SendMessage(TestMessageLevel logLevel, string message)
         {
             if (CanLog)
             {
-                _messageLogger.SendMessage(logLevel, message);
+                messageLogger.SendMessage(logLevel, message);
             }
         }
 
@@ -32,7 +32,7 @@ namespace NSpec.TestAdapter
 
         public void SendMainMessage(string message)
         {
-            SendInformationalMessage(String.Format("{0} {1}: {2}", _adapterName, _adapterVersion, message));
+            SendInformationalMessage(String.Format("{0} {1}: {2}", adapterName, adapterVersion, message));
         }
 
         public void SendDebugMessage(string message)
@@ -66,11 +66,11 @@ namespace NSpec.TestAdapter
             SendErrorMessage(ex.ToString());
         }
 
-        private bool CanLog { get { return _messageLogger != null; } }
+        bool CanLog { get { return messageLogger != null; } }
 
-        private readonly IMessageLogger _messageLogger;
-        private readonly string _adapterVersion;
+        readonly IMessageLogger messageLogger;
+        readonly string adapterVersion;
 
-        private const string _adapterName = "NSpec Test Adapter";
+        const string adapterName = "NSpec Test Adapter";
     }
 }


### PR DESCRIPTION
When opening VS Test Explorer one might incur in exceptions during discovery: this change tries to introduce more logging during that phase, as well as prevent runner from choking on first exception.

Logging funcionalities have been greatly inspired by NUnut VS Test Adapter, and have been refactored into execution phase as well, where some logging already existed.

References to VS TestPlatform ObjectModel DLL were relative to some local project path, and have been changed to a more environment-generic path.