### PR TITLE
Update nspec nuget package to latest stable (1.0.1).

### DIFF
--- a/NSpec.TestAdapter/Discoverer.cs
+++ b/NSpec.TestAdapter/Discoverer.cs
@@ -38,7 +38,7 @@ namespace NSpec.TestAdapter
 			return result.ToArray();
 		}
 
-		public MethodInfo GetAction(Example example)
+		public MethodInfo GetAction(ExampleBase example)
 		{
 			if (example is MethodExample)
 			{

--- a/NSpec.TestAdapter/Executor.cs
+++ b/NSpec.TestAdapter/Executor.cs
@@ -40,7 +40,7 @@ namespace NSpec.TestAdapter
 				.ForEach(example => example.Context.Run(this, false, example.Context.GetInstance()));
 		}
 
-		public void Write(Example example, int level)
+		public void Write(ExampleBase example, int level)
 		{
 			var result = example.Failed()
 				? new TestResultDTO { Outcome = TestOutcome.Failed, StackTrace = example.Exception.StackTrace, Message = example.Exception.Message }

--- a/NSpec.TestAdapter/NSpec.TestAdapter.csproj
+++ b/NSpec.TestAdapter/NSpec.TestAdapter.csproj
@@ -35,8 +35,9 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <HintPath>$(ProgramFiles)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="NSpec">
-      <HintPath>..\packages\nspec.0.9.68\lib\NSpec.dll</HintPath>
+    <Reference Include="NSpec, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\nspec.1.0.1\lib\NSpec.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NSpec.TestAdapter/packages.config
+++ b/NSpec.TestAdapter/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nspec" version="0.9.68" targetFramework="net45" />
+  <package id="nspec" version="1.0.1" targetFramework="net45" />
 </packages>

--- a/SampleSpecs/SampleSpecs.csproj
+++ b/SampleSpecs/SampleSpecs.csproj
@@ -32,9 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NSpec, Version=0.9.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\nspec.0.9.68\lib\NSpec.dll</HintPath>
+    <Reference Include="NSpec, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\nspec.1.0.1\lib\NSpec.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/SampleSpecs/packages.config
+++ b/SampleSpecs/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nspec" version="0.9.68" targetFramework="net45" />
+  <package id="nspec" version="1.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
NSpecTestAdapter does not work with the latest nspec, due to a change in the ILiveFormatter interface.
