### PR TITLE
Execute tests in the test project's assembly directory.

### DIFF
--- a/NSpec.TestAdapter/NSpecExecutor.cs
+++ b/NSpec.TestAdapter/NSpecExecutor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using System.IO;
 
 namespace NSpec.TestAdapter
 {
@@ -38,7 +39,9 @@ namespace NSpec.TestAdapter
 					{
 						testLogger.SendInformationalMessage(String.Format("Running: '{0}'", source));
 
-						sandbox.Content.Execute(this);
+						var assemblyDirectory = new DirectoryInfo(Path.GetDirectoryName(source));
+						Directory.SetCurrentDirectory(assemblyDirectory.FullName);
+                        sandbox.Content.Execute(this);
 					}
 				}
 				catch (Exception ex)
@@ -68,6 +71,8 @@ namespace NSpec.TestAdapter
 				{
 					using (var sandbox = new Sandbox<Executor>(group.Key))
 					{
+						var assemblyDirectory = new DirectoryInfo(Path.GetDirectoryName(group.Key));
+						Directory.SetCurrentDirectory(assemblyDirectory.FullName);
 						sandbox.Content.Execute(this, group.Select(t => t.FullyQualifiedName).ToArray());
 					}
 				}


### PR DESCRIPTION
This restores the behavior NSpecTestAdapter had prior to version 0.2.1, so the tests can access resources copied to the test project's output folder using relative paths, and not mess with the visual studio installation folder - see issue #11 
